### PR TITLE
Reset the counter and total score after each game

### DIFF
--- a/src/components/Leaderboard.js
+++ b/src/components/Leaderboard.js
@@ -5,7 +5,7 @@ import Navbar from "./Navbar";
 import "../style/leaderboard.scss";
 import { useLeaderboard } from "../hooks/leaderboard";
 
-function Leaderboard({ totalScore }) {
+function Leaderboard({ totalScore, setTotalScore, setRoundNumber }) {
   const { loading, leaderboard, playerRank } = useLeaderboard(totalScore);
   if (loading) {
     return <p>Loading...</p>;
@@ -17,7 +17,15 @@ function Leaderboard({ totalScore }) {
         <div className="leaderboard-container">
           <h1 className="title">Leaderboard</h1>
           <HighScoreTable scores={fullLeaderboard} />
-          <Link to="/game">Play again?</Link>
+          <Link
+            to="/game"
+            onClick={() => {
+              setRoundNumber(1);
+              setTotalScore([]);
+            }}
+          >
+            Play again?
+          </Link>
         </div>
       </>
     );

--- a/src/hooks/leaderboard.js
+++ b/src/hooks/leaderboard.js
@@ -11,7 +11,7 @@ function useLeaderboard(newScore) {
   const [playerRank, setPlayerRank] = React.useState(null);
 
   // basic leaderboard fetching
-  function fetchLeaderbaord() {
+  function fetchLeaderboard() {
     const settings = {
       StartPosition: 0,
       MaxResultsCount: 10,
@@ -67,7 +67,7 @@ function useLeaderboard(newScore) {
           addUserScoreToLeaderboard(newScore);
           fetchPlayerRank();
         }
-        fetchLeaderbaord();
+        fetchLeaderboard();
         setLoading(false);
       });
     }, 3000);

--- a/src/utils/private-routes.js
+++ b/src/utils/private-routes.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { BrowserRouter as Router, Route } from "react-router-dom";
-import { useAuth } from "../hooks/auth";
 import Score from "../components/Score";
 import Game from "../components/Game";
 import Leaderboard from "../components/Leaderboard";
@@ -46,7 +45,14 @@ function PrivateRouter({ setTotalScore, totalScore, setRoundNumber, roundNumber 
       <Route
         exact
         path="/leaderboard"
-        render={routeProps => <Leaderboard {...routeProps} totalScore={totalScore} />}
+        render={routeProps => (
+          <Leaderboard
+            {...routeProps}
+            totalScore={totalScore}
+            setTotalScore={setTotalScore}
+            setRoundNumber={setRoundNumber}
+          />
+        )}
       />
     </Router>
   );


### PR DESCRIPTION
Fixes separate issues where counter increments past 5 upon clicking the "Play Again?" link and the leaderboard is never again accessible after each game of 5 rounds.

Addresses issue #73.